### PR TITLE
Add image tag to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,3 +6,4 @@ workflows:
     jobs:
       - docker/publish:
           image: evrone/postgres-with-anonymizer
+          tag: qa-pg-test


### PR DESCRIPTION
Добавил в манифест CircleCI директиву tag на время тестирования. Чтобы не привязываться к SHA коммита в описании релиза (evrone-erp-charts).